### PR TITLE
Minor typo in AppExtension.html

### DIFF
--- a/3.0/com.android.build.gradle.AppExtension.html
+++ b/3.0/com.android.build.gradle.AppExtension.html
@@ -292,7 +292,7 @@ that are specific to your "debug" build type to be located in the <code class="l
 type-, product flavor-, and build variant-specific source set. you can run this task from the
 command line as follows:
 
-</p><pre class="programlisting">./gradlew sourseSets</pre><p>The following sample output describes where Gradle expects to find certain files for the
+</p><pre class="programlisting">./gradlew sourceSets</pre><p>The following sample output describes where Gradle expects to find certain files for the
 "debug" build type:
 
 </p><pre class="programlisting">------------------------------------------------------------


### PR DESCRIPTION
Fixes minor typo in command `./gradlew sourceSets`